### PR TITLE
chore(docker.mk): update DOCKER_REPOSITORY variable to ghcr.io/ for consistency

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -1,12 +1,13 @@
+DOCKER_REPOSITORY = ghcr.io/
+
 FRONT_CCCEV_DOCKERFILE	:= infra/docker/cccev-web-app/Dockerfile
-FRONT_CCCEV_NAME	    := komune-io/cccev-web-app
+FRONT_CCCEV_NAME	    := ${DOCKER_REPOSITORY}komune-io/cccev-web-app
 FRONT_CCCEV_IMG	    	:= ${FRONT_CCCEV_NAME}:${VERSION}
 FRONT_CCCEV_LATEST		:= ${FRONT_CCCEV_NAME}:latest
 
-CCCEV_APP_NAME	   	 	:= komune-io/cccev-gateway
+CCCEV_APP_NAME	   	 	:= ${DOCKER_REPOSITORY}komune-io/cccev-gateway
 CCCEV_APP_IMG	    	:= ${CCCEV_APP_NAME}:${VERSION}
 CCCEV_APP_PACKAGE	   	:= :api-gateway
-
 
 lint: docker-cccev-front-lint
 


### PR DESCRIPTION
chore(docker.mk): update FRONT_CCCEV_NAME and CCCEV_APP_NAME to include DOCKER_REPOSITORY prefix The DOCKER_REPOSITORY variable is updated to ghcr.io/ for consistency across the project. The FRONT_CCCEV_NAME and CCCEV_APP_NAME variables are also updated to include the DOCKER_REPOSITORY prefix to ensure that the correct repository is used when building the Docker images.