### PR TITLE
chore(.gitignore): add infra/docker-compose/infra/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 storybook-static
 infra/dev
+infra/docker-compose/infra/
 
 ### STS ###
 .apt_generated

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
 object Repo {
 	val snapshot: List<String> = listOf(
 		// For fixers
-		"https://oss.sonatype.org/content/repositories/snapshots",
+		"https://s01.oss.sonatype.org/content/repositories/snapshots",
 	)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,7 @@ pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
-		maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
-		maven { url = uri("https://repo.spring.io/milestone") }
+		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
 	}
 }
 


### PR DESCRIPTION
chore(build.gradle.kts): update maven repository URL to use a specific server for snapshots
chore(Dependencies.kt): update snapshot repository URL to use a specific server for snapshots
chore(settings.gradle.kts): update maven repository URL to use a specific server for snapshots

The changes were made to update the maven repository URLs to point to a specific server for snapshots, improving consistency and reliability in fetching dependencies during the build process. The addition to .gitignore ensures that the specified directory is ignored by git.