### PR TITLE
chore(docker.mk): update docker tag destination to use 'komune' organization

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -29,7 +29,7 @@ docker-cccev-api-publish:
 	@docker push ghcr.io/komune-io/${CCCEV_APP_IMG}
 
 docker-cccev-api-promote:
-	@docker tag ${CCCEV_APP_IMG} docker.io/komune-io/${CCCEV_APP_IMG}
+	@docker tag ${CCCEV_APP_IMG} docker.io/komune/${CCCEV_APP_IMG}
 	@docker push docker.io/komune/${CCCEV_APP_IMG}
 
 # docker-cccev-front


### PR DESCRIPTION
The docker tag destination has been updated to use the 'komune' organization instead of 'komune-io'. This change aligns with the organization's naming conventions and ensures consistency across all docker image tags.