### PR TITLE
feat(build): add new version variable f2 to Dependencies.kt for Framework.fixers library

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,6 +18,7 @@ object PluginVersions {
 
 object Versions {
 	val fs = Framework.connect
+	val f2 =  Framework.fixers
 	val s2 =  Framework.fixers
 	val springBoot = PluginVersions.springBoot
 
@@ -46,13 +47,17 @@ object Dependencies {
 			.also(::junit)
 
 		fun f2(scope: Scope) = scope.add(
-			"io.komune.f2:f2-spring-boot-starter-function:${Framework.fixers}",
-			"io.komune.f2:f2-spring-boot-exception-http:${Framework.fixers}"
+			"io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}",
+			"io.komune.f2:f2-spring-boot-exception-http:${Versions.f2}"
+		)
+
+		fun f2Auth(scope: Scope) = scope.add(
+			"io.komune.f2:f2-spring-boot-starter-auth-tenant:${Versions.f2}"
 		)
 
 		fun f2Http(scope: Scope) = scope.add(
-			"io.komune.f2:f2-spring-boot-starter-function-http:${Framework.fixers}",
-			"io.komune.f2:f2-spring-boot-openapi:${Framework.fixers}"
+			"io.komune.f2:f2-spring-boot-starter-function-http:${Versions.f2}",
+			"io.komune.f2:f2-spring-boot-openapi:${Versions.f2}"
 		)
 
 		fun s2EventSouringBc(scope: Scope) = scope.add(

--- a/cccev-test/build.gradle.kts
+++ b/cccev-test/build.gradle.kts
@@ -25,7 +25,9 @@ dependencies {
 
 	implementation(project(Modules.cccev.core))
 
+	Dependencies.Jvm.neo4j(::api)
 	Dependencies.Jvm.f2Http(::api)
+	Dependencies.Jvm.f2Auth(::api)
 	Dependencies.Jvm.s2Bdd(::api)
 	Dependencies.Jvm.Test.dataFaker(::implementation)
 

--- a/cccev-test/src/main/kotlin/cccev/test/EnvironmentCleanerSteps.kt
+++ b/cccev-test/src/main/kotlin/cccev/test/EnvironmentCleanerSteps.kt
@@ -2,12 +2,14 @@ package cccev.test
 
 import io.cucumber.java8.En
 import kotlinx.coroutines.runBlocking
+import org.neo4j.driver.Driver
 import org.springframework.data.neo4j.core.Neo4jClient
 import s2.bdd.data.TestContext
 
 class EnvironmentCleanerSteps(
     private val context: TestContext,
-    private val neo4jTemplate: Neo4jClient
+    private val driver: Driver,
+    private val neo4jClient: Neo4jClient = Neo4jClient.create(driver)
 ): En {
     init {
         Before { _ ->
@@ -27,6 +29,6 @@ class EnvironmentCleanerSteps(
 //    }
 
     private fun cleanDb() = runBlocking {
-        neo4jTemplate.query("MATCH (n) DETACH DELETE n").run()
+        neo4jClient.query("MATCH (n) DETACH DELETE n").run()
     }
 }

--- a/cccev-test/src/test/kotlin/cccev/test/CccevWebSecurityConfig.kt
+++ b/cccev-test/src/test/kotlin/cccev/test/CccevWebSecurityConfig.kt
@@ -1,6 +1,6 @@
 package cccev.test;
 
-import io.komune.i2.spring.boot.auth.config.WebSecurityConfig
+import io.komune.f2.spring.boot.auth.config.WebSecurityConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.context.annotation.Configuration

--- a/cccev-test/src/test/resources/application.yml
+++ b/cccev-test/src/test/resources/application.yml
@@ -28,5 +28,6 @@ ssm:
   chaincode:
     url: http://localhost:9090
 
-i2:
-  issuers:
+f2:
+  tenant:
+    issuer-base-uri:

--- a/libs.mk
+++ b/libs.mk
@@ -4,10 +4,12 @@ VERSION = $(shell cat VERSION)
 
 lint:
 	@echo 'No Lint'
+
 build:
 	./gradlew build publishToMavenLocal -x test
 test:
 	@echo 'No Tests'
+
 publish:
 	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
 


### PR DESCRIPTION
feat(build): add f2Auth and f2Http functions to Dependencies.kt for f2 library feat(build): add Dependencies.Jvm.f2Auth and Dependencies.Jvm.f2Http to cccev-test feat(test): update EnvironmentCleanerSteps.kt to use org.neo4j.driver.Driver for Neo4j feat(test): update CccevWebSecurityConfig.kt to import WebSecurityConfig from f2 library feat(test): update application.yml to change issuer configuration from i2 to f2 The changes were made to introduce support for a new version variable f2 in the Dependencies.kt file for the Framework.fixers library. Additionally, new functions f2Auth and f2Http were added to Dependencies.kt to handle dependencies related to the f2 library. In the cccev-test project, the Dependencies.Jvm.f2Auth and Dependencies.Jvm.f2Http dependencies were added. The EnvironmentCleanerSteps.kt file was updated to use org.neo4j.driver.Driver for Neo4j operations. CccevWebSecurityConfig.kt was updated to import WebSecurityConfig from the f2 library instead of the i2 library. Lastly, the application.yml file was updated to change the issuer configuration from i2 to f2.