### PR TITLE
build(libs.mk): enable parallel build execution for improved build performance

### DIFF
--- a/libs.mk
+++ b/libs.mk
@@ -6,12 +6,12 @@ lint:
 	@echo 'No Lint'
 
 build:
-	./gradlew build publishToMavenLocal -x test
+	./gradlew build publishToMavenLocal -Dorg.gradle.parallel=true -x test
 test:
 	@echo 'No Tests'
 
 publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true --info
 
 promote:
 	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish


### PR DESCRIPTION
build(libs.mk): enable parallel execution for the build process by adding the -Dorg.gradle.parallel=true flag. This change aims to improve build performance by allowing tasks to run concurrently, optimizing resource utilization.