### PR TITLE
chore(gradle.properties): increase JVM memory allocation to 4096m for improved build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.js.ir.output.granularity=whole-program
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
The JVM memory allocation has been increased from 2048m to 4096m in order to enhance the build performance of the project. This change ensures that the Gradle build process has sufficient memory to handle larger tasks efficiently.