### PR TITLE
chore(build): cleanup unused dependencies and update plugins

### DIFF
--- a/cccev-f2/certification-f2/cccev-certification-f2-domain/build.gradle.kts
+++ b/cccev-f2/certification-f2/cccev-certification-f2-domain/build.gradle.kts
@@ -10,7 +10,5 @@ dependencies {
     commonMainApi(project(Modules.cccev.f2.evidence.domain))
     commonMainApi(project(Modules.cccev.f2.requirement.domain))
 
-    commonMainApi("io.ktor:ktor-http:2.2.4")
-
     Dependencies.Mpp.fs(::commonMainApi)
 }

--- a/cccev-f2/unit-f2/cccev-unit-f2-domain/build.gradle.kts
+++ b/cccev-f2/unit-f2/cccev-unit-f2-domain/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("io.komune.fixers.gradle.kotlin.mpp")
-    kotlin("plugin.spring")
+    id("io.komune.fixers.gradle.publish")
     kotlin("plugin.serialization")
 }
 


### PR DESCRIPTION
- Removed the unused `ktor-http` dependency from the certification domain to reduce maintenance overhead.
- Replaced the `spring` plugin with the `publish` plugin in the unit domain to ensure accurate and up-to-date build configuration.





