### PR TITLE
Refactor and Enhance Evidence Type Handling in Unflattening Process

### DIFF
--- a/cccev-client/src/commonMain/kotlin/cccev/client/CertificationClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/CertificationClient.kt
@@ -26,7 +26,7 @@ fun certificationClient(
 }
 
 @JsExport
-open class CertificationClient constructor(val client: F2Client): CertificationApi {
+open class CertificationClient(val client: F2Client): CertificationApi {
     override fun certificationGet(): CertificationGetFunction
         = client.function(this::certificationGet.name)
     override fun certificationCreate(): CertificationCreateFunction

--- a/cccev-client/src/commonMain/kotlin/cccev/client/DataUnitClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/DataUnitClient.kt
@@ -23,7 +23,7 @@ fun dataUnitClient(urlBase: String): F2SupplierSingle<DataUnitClient> = f2Suppli
 }
 
 @JsExport
-open class DataUnitClient constructor(private val client: F2Client): DataUnitApi {
+open class DataUnitClient(private val client: F2Client): DataUnitApi {
     override fun dataUnitGet(): DataUnitGetFunction = client.function(this::dataUnitGet.name)
     override fun dataUnitGetByIdentifier(): DataUnitGetByIdentifierFunction
             = client.function(this::dataUnitGetByIdentifier.name)

--- a/cccev-client/src/commonMain/kotlin/cccev/client/EvidenceTypeClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/EvidenceTypeClient.kt
@@ -22,7 +22,7 @@ fun evidenceTypeClient(urlBase: String): F2SupplierSingle<EvidenceTypeClient> = 
 }
 
 @JsExport
-open class EvidenceTypeClient constructor(private val client: F2Client): EvidenceTypeApi {
+open class EvidenceTypeClient(private val client: F2Client): EvidenceTypeApi {
     override fun evidenceTypeCreate(): EvidenceTypeCreateFunction
         = client.function(this::evidenceTypeCreate.name)
     override fun evidenceTypeGet(): EvidenceTypeGetFunction

--- a/cccev-client/src/commonMain/kotlin/cccev/client/EvidenceTypeListClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/EvidenceTypeListClient.kt
@@ -1,0 +1,39 @@
+package cccev.client
+
+import cccev.f2.evidencetype.EvidenceTypeApi
+import cccev.f2.evidencetype.command.EvidenceTypeCreateFunction
+import cccev.f2.evidencetype.query.EvidenceTypeGetByIdentifierFunction
+import cccev.f2.evidencetype.query.EvidenceTypeGetFunction
+import cccev.f2.evidencetypelist.EvidenceTypeListApi
+import cccev.f2.evidencetypelist.command.EvidenceTypeListCreateFunction
+import cccev.f2.evidencetypelist.query.EvidenceTypeListGetByIdentifierFunction
+import cccev.f2.evidencetypelist.query.EvidenceTypeListGetFunction
+import f2.client.F2Client
+import f2.client.function
+import f2.client.ktor.F2ClientBuilder
+import f2.dsl.fnc.F2SupplierSingle
+import f2.dsl.fnc.f2SupplierSingle
+import kotlin.js.JsExport
+
+fun F2Client.evidenceTypeListClient(): F2SupplierSingle<EvidenceTypeListClient> = f2SupplierSingle {
+    EvidenceTypeListClient(this)
+}
+
+fun evidenceTypeListClient(urlBase: String): F2SupplierSingle<EvidenceTypeListClient> = f2SupplierSingle {
+    EvidenceTypeListClient(
+        F2ClientBuilder.get(urlBase)
+    )
+}
+
+@JsExport
+open class EvidenceTypeListClient(private val client: F2Client): EvidenceTypeListApi {
+
+    override fun evidenceTypeListCreate(): EvidenceTypeListCreateFunction
+            = client.function(this::evidenceTypeListCreate.name)
+
+    override fun evidenceTypeListGet(): EvidenceTypeListGetFunction
+            = client.function(this::evidenceTypeListGet.name)
+
+    override fun evidenceTypeListGetByIdentifier(): EvidenceTypeListGetByIdentifierFunction
+            = client.function(this::evidenceTypeListGetByIdentifier.name)
+}

--- a/cccev-client/src/commonMain/kotlin/cccev/client/InformationConceptClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/InformationConceptClient.kt
@@ -23,7 +23,7 @@ fun informationConceptClient(urlBase: String): F2SupplierSingle<InformationConce
 }
 
 @JsExport
-open class InformationConceptClient constructor(private val client: F2Client): InformationConceptApi {
+open class InformationConceptClient(private val client: F2Client): InformationConceptApi {
     override fun conceptCreate(): InformationConceptCreateFunction = client.function(this::conceptCreate.name)
     override fun conceptUpdate(): InformationConceptUpdateFunction = client.function(this::conceptUpdate.name)
     override fun conceptGet(): InformationConceptGetFunction = client.function(this::conceptGet.name)

--- a/cccev-client/src/commonMain/kotlin/cccev/client/RequirementClient.kt
+++ b/cccev-client/src/commonMain/kotlin/cccev/client/RequirementClient.kt
@@ -29,7 +29,7 @@ fun requirementClient(urlBase: String): F2SupplierSingle<RequirementClient> = f2
 }
 
 @JsExport
-open class RequirementClient constructor(private val client: F2Client): RequirementApi {
+open class RequirementClient(private val client: F2Client): RequirementApi {
     override fun requirementGet(): RequirementGetFunction = client.function(this::requirementGet.name)
     override fun requirementGetByIdentifier(): RequirementGetByIdentifierFunction
             = client.function(this::requirementGetByIdentifier.name)

--- a/cccev-core/src/jvmMain/kotlin/cccev/core/requirement/RequirementAggregateService.kt
+++ b/cccev-core/src/jvmMain/kotlin/cccev/core/requirement/RequirementAggregateService.kt
@@ -36,13 +36,13 @@ class RequirementAggregateService(
     private val sessionFactory: SessionFactory
 ) {
     suspend fun create(command: RequirementCreateCommand): RequirementCreatedEvent = sessionFactory.transaction { session, _ ->
-        val subRequirements = session.findSafeShallowAllById<RequirementEntity>(command.subRequirementIds, "Requirement")
+        val subRequirements = session.findSafeShallowAllById<RequirementEntity>(command.subRequirementIds.orEmpty(), "Requirement")
 
-        val conceptIds = command.conceptIds.toSet() + command.enablingConditionDependencies + command.validatingConditionDependencies
+        val conceptIds = command.conceptIds.orEmpty().toSet() + command.enablingConditionDependencies.orEmpty() + command.validatingConditionDependencies.orEmpty()
         val concepts = session.findSafeShallowAllById<InformationConceptEntity>(conceptIds, "InformationConcept")
             .associateBy(InformationConceptEntity::id)
 
-        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeListIds, "EvidenceType")
+        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeListIds.orEmpty(), "EvidenceType")
 
         val requirement = RequirementEntity().also { requirement ->
             requirement.id = UUID.randomUUID().toString()
@@ -52,13 +52,13 @@ class RequirementAggregateService(
             requirement.description = command.description
             requirement.type = command.type
             requirement.subRequirements = subRequirements.toMutableList()
-            requirement.concepts = command.conceptIds.mapNotNull { concepts[it] }.toMutableList()
+            requirement.concepts = command.conceptIds?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             requirement.evidenceTypes = evidenceTypes.toMutableList()
             requirement.enablingCondition = command.enablingCondition
-            requirement.enablingConditionDependencies = command.enablingConditionDependencies.mapNotNull { concepts[it] }.toMutableList()
+            requirement.enablingConditionDependencies = command.enablingConditionDependencies?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             requirement.required = command.required
             requirement.validatingCondition = command.validatingCondition
-            requirement.validatingConditionDependencies = command.validatingConditionDependencies.mapNotNull { concepts[it] }.toMutableList()
+            requirement.validatingConditionDependencies = command.validatingConditionDependencies?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             requirement.evidenceValidatingCondition = command.evidenceValidatingCondition
             requirement.order = command.order
             requirement.properties = command.properties
@@ -73,31 +73,32 @@ class RequirementAggregateService(
         val requirement = session.load(RequirementEntity::class.java, command.id as String, 1)
             ?: throw NotFoundException("Requirement", command.id)
 
-        val subRequirements = session.findSafeShallowAllById<RequirementEntity>(command.subRequirementIds, "Requirement")
-        val conceptIds = command.conceptIds.toSet() + command.enablingConditionDependencies + command.validatingConditionDependencies
+        val subRequirements = session.findSafeShallowAllById<RequirementEntity>(command.subRequirementIds.orEmpty(), "Requirement")
+        val conceptIds: List<String> = command.conceptIds.orEmpty() + command.enablingConditionDependencies.orEmpty() + command.validatingConditionDependencies.orEmpty()
+
         val concepts = session.findSafeShallowAllById<InformationConceptEntity>(conceptIds, "InformationConcept")
             .associateBy(InformationConceptEntity::id)
-        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeIds, "EvidenceType")
+        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeIds.orEmpty(), "EvidenceType")
 
         session.removeSeveredRelations(
             RequirementEntity.LABEL, command.id, RequirementEntity.HAS_REQUIREMENT, RequirementEntity.LABEL,
-            requirement.subRequirements.map { it.id }, command.subRequirementIds.toSet()
+            requirement.subRequirements.map { it.id }, command.subRequirementIds?.toSet().orEmpty()
         )
         session.removeSeveredRelations(
             RequirementEntity.LABEL, command.id, RequirementEntity.HAS_CONCEPT, InformationConceptEntity.LABEL,
-            requirement.concepts.map { it.id }, command.conceptIds.toSet()
+            requirement.concepts.map { it.id }, command.conceptIds?.toSet().orEmpty()
         )
         session.removeSeveredRelations(
             RequirementEntity.LABEL, command.id, RequirementEntity.ENABLING_DEPENDS_ON, InformationConceptEntity.LABEL,
-            requirement.enablingConditionDependencies.map { it.id }, command.enablingConditionDependencies.toSet()
+            requirement.enablingConditionDependencies.map { it.id }, command.enablingConditionDependencies?.toSet().orEmpty()
         )
         session.removeSeveredRelations(
             RequirementEntity.LABEL, command.id, RequirementEntity.VALIDATION_DEPENDS_ON, InformationConceptEntity.LABEL,
-            requirement.validatingConditionDependencies.map { it.id }, command.validatingConditionDependencies.toSet()
+            requirement.validatingConditionDependencies.map { it.id }, command.validatingConditionDependencies?.toSet().orEmpty()
         )
         session.removeSeveredRelations(
             RequirementEntity.LABEL, command.id, RequirementEntity.HAS_EVIDENCE_TYPE, EvidenceTypeEntity.LABEL,
-            requirement.evidenceTypes.map { it.id }, command.evidenceTypeIds.toSet()
+            requirement.evidenceTypes.map { it.id }, command.evidenceTypeIds?.toSet().orEmpty()
 
         )
 
@@ -105,14 +106,14 @@ class RequirementAggregateService(
             r.name = command.name
             r.description = command.description
             r.type = command.type
-            r.concepts = command.conceptIds.mapNotNull { concepts[it] }.toMutableList()
+            r.concepts = command.conceptIds?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             r.evidenceTypes = evidenceTypes.toMutableList()
             r.subRequirements = subRequirements.toMutableList()
             r.enablingCondition = command.enablingCondition
-            r.enablingConditionDependencies = command.enablingConditionDependencies.mapNotNull { concepts[it] }.toMutableList()
+            r.enablingConditionDependencies = command.enablingConditionDependencies?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             r.required = command.required
             r.validatingCondition = command.validatingCondition
-            r.validatingConditionDependencies = command.validatingConditionDependencies.mapNotNull { concepts[it] }.toMutableList()
+            r.validatingConditionDependencies = command.validatingConditionDependencies?.mapNotNull { concepts[it] }.orEmpty().toMutableList()
             r.evidenceValidatingCondition = command.evidenceValidatingCondition
             r.order = command.order
             r.properties = command.properties

--- a/cccev-core/src/jvmMain/kotlin/cccev/core/requirement/RequirementAggregateService.kt
+++ b/cccev-core/src/jvmMain/kotlin/cccev/core/requirement/RequirementAggregateService.kt
@@ -42,7 +42,7 @@ class RequirementAggregateService(
         val concepts = session.findSafeShallowAllById<InformationConceptEntity>(conceptIds, "InformationConcept")
             .associateBy(InformationConceptEntity::id)
 
-        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeIds, "EvidenceType")
+        val evidenceTypes = session.findSafeShallowAllById<EvidenceTypeEntity>(command.evidenceTypeListIds, "EvidenceType")
 
         val requirement = RequirementEntity().also { requirement ->
             requirement.id = UUID.randomUUID().toString()

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVClient.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVClient.kt
@@ -8,6 +8,7 @@ import cccev.client.RequirementClient
 import cccev.client.certificationClient
 import cccev.client.dataUnitClient
 import cccev.client.evidenceTypeClient
+import cccev.client.evidenceTypeListClient
 import cccev.client.informationConceptClient
 import cccev.client.requirementClient
 import f2.client.ktor.F2ClientBuilder
@@ -27,6 +28,7 @@ class CCCEVClient(
             config: F2ClientConfigLambda<*>? = null
         ): CCCEVClient {
             val f2Client = F2ClientBuilder.get(url, config = config)
+            val evidenceTypeListClient = f2Client.evidenceTypeListClient().invoke()
             val evidenceTypeClient = f2Client.evidenceTypeClient().invoke()
             val informationConceptClient = f2Client.informationConceptClient().invoke()
             val certificationClient =  f2Client.certificationClient().invoke()
@@ -38,7 +40,9 @@ class CCCEVClient(
                 certificationClient = certificationClient,
                 requirementClient = requirementClient,
                 dataUnitClient = dataUnitClient,
-                CCCEVGraphClient(evidenceTypeClient = evidenceTypeClient,
+                CCCEVGraphClient(
+                    evidenceTypeListClient = evidenceTypeListClient,
+                    evidenceTypeClient = evidenceTypeClient,
                     informationConceptClient = informationConceptClient,
                     requirementClient = requirementClient,
                     dataUnitClient = dataUnitClient,

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVGraphClient.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVGraphClient.kt
@@ -11,10 +11,8 @@ import cccev.dsl.client.model.unflatten
 import cccev.dsl.model.DataUnitDTO
 import cccev.dsl.model.DataUnitId
 import cccev.dsl.model.EvidenceType
-import cccev.dsl.model.EvidenceTypeBase
 import cccev.dsl.model.EvidenceTypeId
 import cccev.dsl.model.EvidenceTypeList
-import cccev.dsl.model.EvidenceTypeListBase
 import cccev.dsl.model.EvidenceTypeListId
 import cccev.dsl.model.InformationConcept
 import cccev.dsl.model.InformationConceptId
@@ -66,7 +64,7 @@ class CCCEVGraphClient(
         val requirementNodes = requirements.groupBy(Requirement::identifier)
             .mapValues { (_, requirements) -> requirements.firstOrNull { it !is RequirementRef } ?: requirements.first() }
 
-        val informationConceptNodes = requirements.flatMap { requirement -> requirement.hasConcept.orEmpty() }
+        val informationConceptNodes = requirements.flatMap { requirement -> requirement.hasConcept ?: emptyList() }
             .groupBy(InformationConcept::identifier)
             .mapValues { (_, concepts) -> concepts.firstOrNull { it !is InformationConceptRef } ?: concepts.first() }
 
@@ -168,17 +166,17 @@ class CCCEVGraphClient(
             identifier = requirement.identifier,
             name = requirement.name,
             description = requirement.description,
-            conceptIds = requirement.hasConcept?.map { context.processedConcepts[it.identifier]!! }.orEmpty(),
+            conceptIds = requirement.hasConcept?.map { context.processedConcepts[it.identifier]!! },
             evidenceTypeListIds = requirement.hasEvidenceTypeList?.map { context.processedEvidenceTypeLists[it.identifier]!! }
-                .orEmpty(),
-            subRequirementIds = requirement.hasRequirement?.map { context.processedRequirements[it.identifier]!! }.orEmpty(),
+                ,
+            subRequirementIds = requirement.hasRequirement?.map { context.processedRequirements[it.identifier]!! },
             kind = RequirementKind.valueOf(requirement.kind),
             type = requirement.type?.toString(),
             enablingCondition = requirement.enablingCondition,
-            enablingConditionDependencies = requirement.enablingConditionDependencies.map { context.processedConcepts[it]!! },
+            enablingConditionDependencies = requirement.enablingConditionDependencies?.map { context.processedConcepts[it]!! },
             required = requirement.required,
             validatingCondition = requirement.validatingCondition,
-            validatingConditionDependencies = requirement.validatingConditionDependencies.map { context.processedConcepts[it]!! },
+            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it]!! },
             order = requirement.order,
             properties = requirement.properties
         ).invokeWith(requirementClient.requirementCreate()).id
@@ -193,16 +191,16 @@ class CCCEVGraphClient(
             id = id,
             name = requirement.name,
             description = requirement.description,
-            conceptIds = requirement.hasConcept?.map { context.processedConcepts[it.identifier]!! }.orEmpty(),
+            conceptIds = requirement.hasConcept?.map { context.processedConcepts[it.identifier]!! },
             evidenceTypeIds = requirement.hasEvidenceTypeList?.map { context.processedEvidenceTypeLists[it.identifier]!! }
-                .orEmpty(),
-            subRequirementIds = requirement.hasRequirement?.map { context.processedRequirements[it.identifier]!! }.orEmpty(),
+                ,
+            subRequirementIds = requirement.hasRequirement?.map { context.processedRequirements[it.identifier]!! },
             type = requirement.type,
             enablingCondition = requirement.enablingCondition,
-            enablingConditionDependencies = requirement.enablingConditionDependencies.map { context.processedConcepts[it]!! },
+            enablingConditionDependencies = requirement.enablingConditionDependencies?.map { context.processedConcepts[it]!! },
             required = requirement.required,
             validatingCondition = requirement.validatingCondition,
-            validatingConditionDependencies = requirement.validatingConditionDependencies.map { context.processedConcepts[it]!! },
+            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it]!! },
             order = requirement.order,
             properties = requirement.properties,
             evidenceValidatingCondition = requirement.evidenceValidatingCondition,
@@ -214,7 +212,7 @@ class CCCEVGraphClient(
         context: Context
     ) {
         if (etl.identifier !in context.processedEvidenceTypeLists) {
-            etl.specifiesEvidenceType.forEach { et ->
+            etl.specifiesEvidenceType?.forEach { et ->
                 if (et.identifier !in context.processedEvidenceTypes) {
                     val evidenceTypeId = et.save(context)
                     context.processedEvidenceTypes[et.identifier] = evidenceTypeId
@@ -320,7 +318,7 @@ class CCCEVGraphClient(
             identifier = identifier,
             name = name,
             description = description,
-            specifiesEvidenceType = specifiesEvidenceType.map { context.processedEvidenceTypes[it.identifier]!! }
+            specifiesEvidenceType = specifiesEvidenceType?.map { context.processedEvidenceTypes[it.identifier]!! }
         ).invokeWith(evidenceTypeListClient.evidenceTypeListCreate()).id
     }
 

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -131,32 +131,36 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
     val subRequirements = subRequirementIds.map {
         graph.requirements[it]?.unflatten(graph)
             ?: throw NotFoundException("Requirement", it)
-    }
+    }.ifEmpty { null }
     val concepts = conceptIdentifiers.map {
         graph.concepts[it]?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", it)
-    }
+    }.ifEmpty { null }
     val evidenceTypes = evidenceTypeIds.map {
         graph.evidenceTypes[it]?.unflatten(graph)
             ?: throw NotFoundException("EvidenceType", it)
-    }
+    }.ifEmpty { null }
 
-    val evidenceTypeLists = listOf(EvidenceTypeListBase(
-        name = "default",
-        description = "default",
-        identifier = "default",
-        specifiesEvidenceType = evidenceTypes
-    ))
+
+    val evidenceTypeLists =  if(!evidenceTypes.isNullOrEmpty()) {
+        listOf(EvidenceTypeListBase(
+            name = "default",
+            description = "default",
+            identifier = "default",
+            specifiesEvidenceType = evidenceTypes
+        ))
+    } else null
+
 
 
     val enablingConditionDependencies = enablingConditionDependencies.map {
         graph.concepts[it]?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", it)
-    }.map { it.id }
+    }.map { it.id }.ifEmpty { null }
     val validatingConditionDependencies = validatingConditionDependencies.map {
         graph.concepts[it]?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", it)
-    }.map { it.id }
+    }.map { it.id }.ifEmpty { null }
     return when(RequirementKind.valueOf(kind)) {
         RequirementKind.CONSTRAINT -> asConstant(
             enablingConditionDependencies,
@@ -183,11 +187,11 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
 }
 
 private fun RequirementFlat.asInformationRequirement(
-    enablingConditionDependencies: List<InformationConceptId>,
-    validatingConditionDependencies: List<InformationConceptId>,
-    subRequirements: List<Requirement>,
-    concepts: List<InformationConcept>,
-    evidenceTypeLists: List<EvidenceTypeListBase>
+    enablingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConceptId>?,
+    subRequirements: List<Requirement>?,
+    concepts: List<InformationConcept>?,
+    evidenceTypeLists: List<EvidenceTypeListBase>?
 ) = InformationRequirement(
     id = id,
     identifier = identifier,
@@ -212,11 +216,11 @@ private fun RequirementFlat.asInformationRequirement(
 )
 
 private fun RequirementFlat.asCriterion(
-    enablingConditionDependencies: List<InformationConceptId>,
-    validatingConditionDependencies: List<InformationConceptId>,
-    subRequirements: List<Requirement>,
-    concepts: List<InformationConcept>,
-    evidenceTypeLists: List<EvidenceTypeListBase>
+    enablingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConceptId>?,
+    subRequirements: List<Requirement>?,
+    concepts: List<InformationConcept>?,
+    evidenceTypeLists: List<EvidenceTypeListBase>?
 ) = Criterion(
     id = id,
     identifier = identifier,
@@ -239,11 +243,11 @@ private fun RequirementFlat.asCriterion(
 )
 
 private fun RequirementFlat.asConstant(
-    enablingConditionDependencies: List<InformationConceptId>,
-    validatingConditionDependencies: List<InformationConceptId>,
-    subRequirements: List<Requirement>,
-    concepts: List<InformationConcept>,
-    evidenceTypeLists: List<EvidenceTypeListBase>
+    enablingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConceptId>?,
+    subRequirements: List<Requirement>?,
+    concepts: List<InformationConcept>?,
+    evidenceTypeLists: List<EvidenceTypeListBase>?
 ) = Constraint(
     id = id,
     identifier = identifier,

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -6,9 +6,7 @@ import cccev.dsl.model.Criterion
 import cccev.dsl.model.DataUnit
 import cccev.dsl.model.DataUnitOption
 import cccev.dsl.model.DataUnitType
-import cccev.dsl.model.EvidenceType
 import cccev.dsl.model.EvidenceTypeBase
-import cccev.dsl.model.EvidenceTypeList
 import cccev.dsl.model.EvidenceTypeListBase
 import cccev.dsl.model.InformationConcept
 import cccev.dsl.model.InformationConceptBase
@@ -244,7 +242,7 @@ private fun RequirementFlat.asConstant(
     enablingConditionDependencies: List<InformationConceptId>,
     validatingConditionDependencies: List<InformationConceptId>,
     subRequirements: List<Requirement>,
-    concepts: List<InformationConcept>
+    concepts: List<InformationConcept>,
     evidenceTypeLists: List<EvidenceTypeListBase>
 ) = Constraint(
     id = id,

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -8,6 +8,8 @@ import cccev.dsl.model.DataUnitOption
 import cccev.dsl.model.DataUnitType
 import cccev.dsl.model.EvidenceType
 import cccev.dsl.model.EvidenceTypeBase
+import cccev.dsl.model.EvidenceTypeList
+import cccev.dsl.model.EvidenceTypeListBase
 import cccev.dsl.model.InformationConcept
 import cccev.dsl.model.InformationConceptBase
 import cccev.dsl.model.InformationConceptId
@@ -140,6 +142,15 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
         graph.evidenceTypes[it]?.unflatten(graph)
             ?: throw NotFoundException("EvidenceType", it)
     }
+
+    val evidenceTypeLists = listOf(EvidenceTypeListBase(
+        name = "default",
+        description = "default",
+        identifier = "default",
+        specifiesEvidenceType = evidenceTypes
+    ))
+
+
     val enablingConditionDependencies = enablingConditionDependencies.map {
         graph.concepts[it]?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", it)
@@ -153,17 +164,22 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
             enablingConditionDependencies,
             validatingConditionDependencies,
             subRequirements,
-            concepts
+            concepts,
+            evidenceTypeLists
         )
         RequirementKind.CRITERION -> asCriterion(
             enablingConditionDependencies,
             validatingConditionDependencies,
-            subRequirements
+            subRequirements,
+            concepts,
+            evidenceTypeLists
         )
         RequirementKind.INFORMATION -> asInformationRequirement(
             enablingConditionDependencies,
             validatingConditionDependencies,
-            subRequirements
+            subRequirements,
+            concepts,
+            evidenceTypeLists
         )
     }
 }
@@ -171,11 +187,12 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
 private fun RequirementFlat.asInformationRequirement(
     enablingConditionDependencies: List<InformationConceptId>,
     validatingConditionDependencies: List<InformationConceptId>,
-    subRequirements: List<Requirement>
+    subRequirements: List<Requirement>,
+    concepts: List<InformationConcept>,
+    evidenceTypeLists: List<EvidenceTypeListBase>
 ) = InformationRequirement(
     id = id,
     identifier = identifier,
-//        kind = RequirementKind.valueOf(kind)
     description = description,
     type = type,
     name = name,
@@ -184,7 +201,7 @@ private fun RequirementFlat.asInformationRequirement(
     order = order,
     properties = properties,
     required = required,
-//        concepts = concepts,
+    hasConcept = concepts,
 //        evidenceTypes = evidenceTypes,
     enablingConditionDependencies = enablingConditionDependencies,
     validatingCondition = validatingCondition,
@@ -192,36 +209,33 @@ private fun RequirementFlat.asInformationRequirement(
     evidenceValidatingCondition = evidenceValidatingCondition,
     hasRequirement = subRequirements,
     isDerivedFrom = emptyList(),
-    hasConcept = emptyList(),
-    hasEvidenceTypeList = emptyList(),
+    hasEvidenceTypeList = evidenceTypeLists,
     isRequirementOf = emptyList(),
 )
 
 private fun RequirementFlat.asCriterion(
     enablingConditionDependencies: List<InformationConceptId>,
     validatingConditionDependencies: List<InformationConceptId>,
-    subRequirements: List<Requirement>
+    subRequirements: List<Requirement>,
+    concepts: List<InformationConcept>,
+    evidenceTypeLists: List<EvidenceTypeListBase>
 ) = Criterion(
     id = id,
     identifier = identifier,
-//        kind = RequirementKind.valueOf(kind)
     description = description,
     type = type,
     name = name,
-//        subRequirements = subRequirements.toMutableList(),
     enablingCondition = enablingCondition,
     order = order,
     properties = properties,
     required = required,
-//        concepts = concepts,
-//        evidenceTypes = evidenceTypes,
+    hasConcept = concepts,
     enablingConditionDependencies = enablingConditionDependencies,
     validatingCondition = validatingCondition,
     validatingConditionDependencies = validatingConditionDependencies,
     hasRequirement = subRequirements,
+    hasEvidenceTypeList = evidenceTypeLists,
     isDerivedFrom = emptyList(),
-    hasConcept = emptyList(),
-    hasEvidenceTypeList = emptyList(),
     isRequirementOf = emptyList(),
     evidenceValidatingCondition = evidenceValidatingCondition
 )
@@ -231,27 +245,24 @@ private fun RequirementFlat.asConstant(
     validatingConditionDependencies: List<InformationConceptId>,
     subRequirements: List<Requirement>,
     concepts: List<InformationConcept>
+    evidenceTypeLists: List<EvidenceTypeListBase>
 ) = Constraint(
     id = id,
     identifier = identifier,
-//        kind = RequirementKind.valueOf(kind)
     description = description,
     type = type,
     name = name,
-//        subRequirements = subRequirements.toMutableList(),
     enablingCondition = enablingCondition,
     order = order,
     properties = properties,
     required = required,
-//        concepts = concepts,
-//        evidenceTypes = evidenceTypes,
     enablingConditionDependencies = enablingConditionDependencies,
     validatingCondition = validatingCondition,
     validatingConditionDependencies = validatingConditionDependencies,
     hasRequirement = subRequirements,
     isDerivedFrom = emptyList(),
     hasConcept = concepts,
-    hasEvidenceTypeList = emptyList(),
+    hasEvidenceTypeList = evidenceTypeLists,
     isRequirementOf = emptyList(),
     evidenceValidatingCondition = evidenceValidatingCondition
 )
@@ -281,7 +292,7 @@ fun DataUnitOption.unflatten(): DataUnitOption {
     )
 }
 
-fun EvidenceTypeFlat.unflatten(graph: CccevFlatGraph): EvidenceType {
+fun EvidenceTypeFlat.unflatten(graph: CccevFlatGraph): EvidenceTypeBase {
     return EvidenceTypeBase(
         identifier = identifier,
         name = name,

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Evidence.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Evidence.kt
@@ -13,6 +13,14 @@ import kotlinx.serialization.Serializable
 typealias EvidenceId = String
 
 /**
+ * The unique identifier of the evidence.
+ * @visual json "0d33dee4-4c31-410a-b54f-e57d18e9c10b"
+ * @title DSL/EvidenceId
+ * @d2 model
+ */
+typealias EvidenceIdentifier = String
+
+/**
  * Proof that a Requirement is met.
  *
  * The class Evidence provides the means to support responses to Criteria or to a concrete Information Requirement
@@ -28,7 +36,14 @@ typealias EvidenceId = String
 @JsExport
 @JsName("EvidenceDTO")
 interface EvidenceDTO {
-    val identifier: EvidenceId
+    /**
+     * The unique id of the evidence.
+     */
+    val id: EvidenceId
+    /**
+     * The unique identifier of the evidence.
+     */
+    val identifier: EvidenceIdentifier
     /**
      * Evidence Type that specifies characteristics of the Evidence.
      */
@@ -64,7 +79,8 @@ interface EvidenceDTO {
  */
 @Serializable
 open class Evidence(
-    override val identifier: EvidenceId,
+    override val id: EvidenceId,
+    override val identifier: EvidenceIdentifier,
     override val isConformantTo: List<EvidenceTypeId> = emptyList(),
     override val supportsValue: List<SupportedValueId> = emptyList(),
     override val supportsConcept: List<InformationConceptId> = emptyList(),

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/EvidenceType.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/EvidenceType.kt
@@ -46,14 +46,14 @@ interface EvidenceTypeList {
 	val description: String
 	val identifier: EvidenceTypeListId
 	val name: String
-	val specifiesEvidenceType: List<EvidenceType>
+	val specifiesEvidenceType: List<EvidenceType>?
 }
 @Serializable
 open class EvidenceTypeListBase(
     override val description: String,
     override val identifier: EvidenceTypeListId,
     override val name: String,
-    override val specifiesEvidenceType: List<EvidenceTypeBase> = emptyList()
+    override val specifiesEvidenceType: List<EvidenceTypeBase>? = null
 ): EvidenceTypeList
 
 @JsExport

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/EvidenceType.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/EvidenceType.kt
@@ -14,6 +14,15 @@ import kotlinx.serialization.Serializable
 typealias EvidenceTypeListId = String
 
 /**
+ * The unique id of the evidence type list.
+ * @visual json "TheEvidenceTypeListIdentifier"
+ * @parent [EvidenceTypeList]
+ * @title EvidenceTypeId
+ * @d2 model
+ */
+typealias EvidenceTypeListIdentifier = String
+
+/**
  * The unique id of the evidence type.
  * @visual json "082f9b5b-4ffa-4e95-8288-2de2972cade5"
  * @parent [EvidenceType]

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
@@ -34,11 +34,11 @@ sealed interface Requirement {
     val hasConcept: List<InformationConcept>?
     val hasEvidenceTypeList: List<EvidenceTypeList>?
     val enablingCondition: String?
-    val enablingConditionDependencies: List<InformationConceptIdentifier>
+    val enablingConditionDependencies: List<InformationConceptIdentifier>?
     val required: Boolean
     val validatingCondition: String?
     val evidenceValidatingCondition: String?
-    val validatingConditionDependencies: List<InformationConceptIdentifier>
+    val validatingConditionDependencies: List<InformationConceptIdentifier>?
     val order: Int?
     val properties: Map<String, String>?
 }
@@ -60,10 +60,10 @@ open class Criterion(
     override val isDerivedFrom: List<ReferenceFramework>? = emptyList(),
     override var isRequirementOf: List<Requirement>? = emptyList(),
     override val enablingCondition: String?,
-    override val enablingConditionDependencies: List<InformationConceptIdentifier>,
+    override val enablingConditionDependencies: List<InformationConceptIdentifier>?,
     override val required: Boolean,
     override val validatingCondition: String?,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>,
+    override val validatingConditionDependencies: List<InformationConceptIdentifier>?,
     override val order: Int?,
     override val properties: Map<String, String>?,
     override val evidenceValidatingCondition: String?,
@@ -101,10 +101,10 @@ open class InformationRequirement(
     override val isDerivedFrom: List<ReferenceFramework>? = emptyList(),
     override var isRequirementOf: List<Requirement>? = emptyList(),
     override val enablingCondition: String?,
-    override val enablingConditionDependencies: List<InformationConceptIdentifier>,
+    override val enablingConditionDependencies: List<InformationConceptIdentifier>?,
     override val required: Boolean,
     override val validatingCondition: String?,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>,
+    override val validatingConditionDependencies: List<InformationConceptIdentifier>?,
     override val order: Int?,
     override val properties: Map<String, String>?,
     override val evidenceValidatingCondition: String?,
@@ -138,10 +138,10 @@ open class Constraint(
     override val isDerivedFrom: List<ReferenceFramework>? = emptyList(),
     override var isRequirementOf: List<Requirement>? = emptyList(),
     override val enablingCondition: String?,
-    override val enablingConditionDependencies: List<InformationConceptIdentifier>,
+    override val enablingConditionDependencies: List<InformationConceptIdentifier>?,
     override val required: Boolean,
     override val validatingCondition: String?,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>,
+    override val validatingConditionDependencies: List<InformationConceptIdentifier>?,
     override val order: Int?,
     override val properties: Map<String, String>?,
     override val evidenceValidatingCondition: String?,

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
@@ -32,7 +32,7 @@ sealed interface Requirement {
     val hasRequirement: List<Requirement>?
     var isRequirementOf: List<Requirement>?
     val hasConcept: List<InformationConcept>?
-    val hasEvidenceTypeList: List<EvidenceTypeListBase>?
+    val hasEvidenceTypeList: List<EvidenceTypeList>?
     val enablingCondition: String?
     val enablingConditionDependencies: List<InformationConceptIdentifier>
     val required: Boolean
@@ -97,7 +97,7 @@ open class InformationRequirement(
     override val type: String? = null,
     override val hasConcept: List<InformationConcept>? = emptyList(),
     override val hasRequirement: List<Requirement>? = emptyList(),
-    override val hasEvidenceTypeList: List<EvidenceTypeListBase>? = emptyList(),
+    override val hasEvidenceTypeList: List<EvidenceTypeList>? = emptyList(),
     override val isDerivedFrom: List<ReferenceFramework>? = emptyList(),
     override var isRequirementOf: List<Requirement>? = emptyList(),
     override val enablingCondition: String?,

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/CccevFlatGraph.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/CccevFlatGraph.kt
@@ -6,6 +6,7 @@ import cccev.dsl.model.DataUnitOption
 import cccev.dsl.model.DataUnitOptionDTO
 import cccev.dsl.model.DataUnitOptionIdentifier
 import cccev.dsl.model.EvidenceTypeId
+import cccev.dsl.model.EvidenceTypeListId
 import cccev.dsl.model.InformationConceptIdentifier
 import cccev.dsl.model.RequirementCertificationId
 import cccev.dsl.model.RequirementIdentifier
@@ -20,6 +21,8 @@ import cccev.f2.concept.model.InformationConceptFlat
 import cccev.f2.concept.model.InformationConceptFlatDTO
 import cccev.f2.evidencetype.model.EvidenceTypeFlat
 import cccev.f2.evidencetype.model.EvidenceTypeFlatDTO
+import cccev.f2.evidencetypelist.model.EvidenceTypeListFlat
+import cccev.f2.evidencetypelist.model.EvidenceTypeListFlatDTO
 import cccev.f2.requirement.model.RequirementFlat
 import cccev.f2.requirement.model.RequirementFlatDTO
 import cccev.f2.unit.model.DataUnitFlat
@@ -33,6 +36,7 @@ interface CccevFlatGraphDTO {
     val requirementCertifications: Map<RequirementCertificationId, RequirementCertificationFlatDTO>
     val requirements: Map<RequirementIdentifier, RequirementFlatDTO>
     val concepts: Map<InformationConceptIdentifier, InformationConceptFlatDTO>
+    val evidenceListTypes: Map<EvidenceTypeListId, EvidenceTypeListFlatDTO>
     val evidenceTypes: Map<EvidenceTypeId, EvidenceTypeFlatDTO>
     val units: Map<DataUnitIdentifier, DataUnitFlatDTO>
     val unitOptions: Map<DataUnitOptionIdentifier, DataUnitOptionDTO>
@@ -45,6 +49,7 @@ class CccevFlatGraph: CccevFlatGraphDTO {
     override val requirementCertifications: MutableMap<RequirementCertificationId, RequirementCertificationFlat> = mutableMapOf()
     override val requirements: MutableMap<RequirementIdentifier, RequirementFlat> = mutableMapOf()
     override val concepts: MutableMap<InformationConceptIdentifier, InformationConceptFlat> = mutableMapOf()
+    override val evidenceListTypes: MutableMap<EvidenceTypeListId, EvidenceTypeListFlat> = mutableMapOf()
     override val evidenceTypes: MutableMap<EvidenceTypeId, EvidenceTypeFlat> = mutableMapOf()
     override val units: MutableMap<DataUnitIdentifier, DataUnitFlat> = mutableMapOf()
     override val unitOptions: MutableMap<DataUnitOptionIdentifier, DataUnitOption> = mutableMapOf()

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeFlat.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeFlat.kt
@@ -21,7 +21,7 @@ interface EvidenceTypeFlatDTO {
     /**
      * Identifier of the evidence type.
      */
-    val identifier: EvidenceTypeId
+    val identifier: EvidenceTypeIdentifier
 
     /**
      * Name of the evidence type.

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeId.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeId.kt
@@ -1,7 +1,0 @@
-package cccev.f2.evidencetype.model
-
-/**
- * @d2 hidden
- * @example "a01eeb46-b420-494f-958e-c622fa1c57f1"
- */
-//typealias EvidenceTypeId = String

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeListId.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetype/model/EvidenceTypeListId.kt
@@ -1,2 +1,0 @@
-package cccev.f2.evidencetype.model
-

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/D2EvidenceTypePage.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/D2EvidenceTypePage.kt
@@ -1,0 +1,15 @@
+package cccev.f2.evidencetypelist
+
+/**
+ * Group of Evidence Types for conforming to a Requirement.
+ * An Evidence Type List is satisfied, if and only if, for all included Evidence Types in this List,
+ * corresponding conformant Evidence(s) are supporting the Requirement having this List.
+ * The Evidence Type List describes thus an AND condition on the different Evidence Types within the list
+ * and an OR condition between two or more Evidence Type Lists. Combinations of alternative Lists can be provided
+ * for a respondent of a Requirement to choose amongst them.
+ *
+ * See https://semiceu.github.io/CCCEV/releases/2.1.0/#EvidenceTypeList
+ * @d2 page
+ * @title Evidence Type
+ */
+interface D2EvidenceTypeListPage

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/EvidenceTypeListApi.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/EvidenceTypeListApi.kt
@@ -1,0 +1,23 @@
+package cccev.f2.evidencetypelist
+
+import cccev.f2.evidencetype.command.EvidenceTypeCreateFunction
+import cccev.f2.evidencetype.query.EvidenceTypeGetByIdentifierFunction
+import cccev.f2.evidencetype.query.EvidenceTypeGetFunction
+import cccev.f2.evidencetypelist.command.EvidenceTypeListCreateFunction
+import cccev.f2.evidencetypelist.query.EvidenceTypeListGetByIdentifierFunction
+import cccev.f2.evidencetypelist.query.EvidenceTypeListGetFunction
+
+/**
+ * @d2 api
+ * @parent [cccev.core.evidencetypelist.D2EvidenceListTypePage]
+ */
+interface EvidenceTypeListApi: EvidenceTypeListCommandApi, EvidenceTypeListQueryApi
+
+interface EvidenceTypeListCommandApi {
+    fun evidenceTypeListCreate(): EvidenceTypeListCreateFunction
+}
+
+interface EvidenceTypeListQueryApi {
+    fun evidenceTypeListGet(): EvidenceTypeListGetFunction
+    fun evidenceTypeListGetByIdentifier(): EvidenceTypeListGetByIdentifierFunction
+}

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/command/EvidenceTypeListCreateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/command/EvidenceTypeListCreateCommand.kt
@@ -1,0 +1,71 @@
+package cccev.f2.evidencetypelist.command
+
+import cccev.dsl.model.EvidenceTypeListId
+import cccev.dsl.model.EvidenceTypeListIdentifier
+import f2.dsl.fnc.F2Function
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlinx.serialization.Serializable
+
+/**
+ * Create an evidence type
+ * @d2 function
+ * @parent [D2EvidenceTypePage]
+ */
+typealias EvidenceTypeListCreateFunction = F2Function<EvidenceTypeListCreateCommand, EvidenceTypeListCreatedEvent>
+
+/**
+ * @d2 command
+ */
+@JsExport
+@JsName("EvidenceTypeListCreateCommandDTO")
+interface EvidenceTypeListCreateCommandDTO {
+    /**
+     * Custom unique id for the evidence type. If null, a random id will be generated.
+     */
+    val id: EvidenceTypeListId?
+
+    /**
+     * Custom unique identifier for the evidence type. If null, a random id will be generated.
+     */
+    val identifier: EvidenceTypeListIdentifier?
+
+    val name: String
+
+    val description: String
+
+    val specifiesEvidenceType: List<EvidenceTypeListIdentifier>?
+
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListCreateCommand(
+    override val id: EvidenceTypeListId? = null,
+    override val identifier: EvidenceTypeListIdentifier? = null,
+    override val specifiesEvidenceType: List<EvidenceTypeListIdentifier>? = null,
+    override val name: String,
+    override val description: String
+): EvidenceTypeListCreateCommandDTO
+
+/**
+ * @d2 event
+ */
+@JsExport
+@JsName("EvidenceTypeListCreatedEventDTO")
+interface EvidenceTypeListCreatedEventDTO {
+    /**
+     * Id of the evidence type as specified in the command, or random if not.
+     */
+    val id: EvidenceTypeListId
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListCreatedEvent(
+    override val id: EvidenceTypeListId,
+): EvidenceTypeListCreatedEventDTO

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/model/EvidenceTypeListFlat.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/model/EvidenceTypeListFlat.kt
@@ -1,0 +1,55 @@
+package cccev.f2.evidencetypelist.model
+
+import cccev.dsl.model.EvidenceTypeId
+import cccev.dsl.model.EvidenceTypeIdentifier
+import cccev.dsl.model.EvidenceTypeListId
+import cccev.dsl.model.EvidenceTypeListIdentifier
+import cccev.dsl.model.InformationConceptIdentifier
+import cccev.f2.evidencetype.D2EvidenceTypePage
+import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
+
+/**
+ * @d2 model
+ * @parent [D2EvidenceTypeListPage]
+ * @order 10
+ */
+@JsExport
+interface EvidenceTypeListFlatDTO {
+    /**
+     * Identifier of the evidence type.
+     */
+    val id: EvidenceTypeListId
+    /**
+     * Identifier of the evidence type.
+     */
+    val identifier: EvidenceTypeListIdentifier
+
+    /**
+     * Name of the evidence type.
+     * @example [cccev.f2.evidencetypelist.model.EvidenceTypeList.name]
+     */
+    val name: String
+
+    /**
+     * description of the evidence type.
+     * @example [cccev.f2.evidencetypelist.model.EvidenceTypeList.description]
+     */
+    val description: String
+
+
+    val specifiesEvidenceType: List<EvidenceTypeListIdentifier>?
+
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListFlat(
+    override val id: EvidenceTypeId,
+    override val identifier: EvidenceTypeIdentifier,
+    override val name: String,
+    override val description: String,
+    override val specifiesEvidenceType: List<EvidenceTypeListIdentifier>?,
+): EvidenceTypeListFlatDTO

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/query/EvidenceTypeListGetByIdentifierQuery.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/query/EvidenceTypeListGetByIdentifierQuery.kt
@@ -1,0 +1,62 @@
+package cccev.f2.evidencetypelist.query
+
+import cccev.dsl.model.EvidenceTypeIdentifier
+import cccev.dsl.model.EvidenceTypeListIdentifier
+import cccev.f2.CccevFlatGraph
+import cccev.f2.CccevFlatGraphDTO
+import cccev.f2.evidencetype.D2EvidenceTypePage
+import cccev.f2.evidencetype.model.EvidenceTypeFlat
+import cccev.f2.evidencetype.model.EvidenceTypeFlatDTO
+import cccev.f2.evidencetypelist.model.EvidenceTypeListFlat
+import cccev.f2.evidencetypelist.model.EvidenceTypeListFlatDTO
+import f2.dsl.fnc.F2Function
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlinx.serialization.Serializable
+
+/**
+ * Get an evidence type by its identifier.
+ * @d2 function
+ * @parent [D2EvidenceTypePage]
+ */
+typealias EvidenceTypeListGetByIdentifierFunction = F2Function<EvidenceTypeListGetByIdentifierQuery, EvidenceTypeListGetByIdentifierResult>
+
+/**
+ * @d2 query
+ * @parent [EvidenceTypeListGetFunction]
+ */
+@JsExport
+@JsName("EvidenceTypeListGetByIdentifierQueryDTO")
+interface EvidenceTypeListGetByIdentifierQueryDTO {
+    /**
+     * Identifier of the data unit to get.
+     */
+    val identifier: EvidenceTypeListIdentifier
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListGetByIdentifierQuery(
+    override val identifier: EvidenceTypeListIdentifier
+): EvidenceTypeListGetByIdentifierQueryDTO
+
+/**
+ * @d2 result
+ * @parent [EvidenceTypeListGetFunction]
+ */
+@JsExport
+interface EvidenceTypeListGetByIdentifierResultDTO {
+    val item: EvidenceTypeListFlatDTO?
+    val graph: CccevFlatGraphDTO
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListGetByIdentifierResult(
+    override val item: EvidenceTypeListFlat?,
+    override val graph: CccevFlatGraph
+): EvidenceTypeListGetByIdentifierResultDTO

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/query/EvidenceTypeListGetQuery.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/query/EvidenceTypeListGetQuery.kt
@@ -1,0 +1,60 @@
+package cccev.f2.evidencetypelist.query
+
+import cccev.dsl.model.EvidenceTypeId
+import cccev.f2.CccevFlatGraph
+import cccev.f2.CccevFlatGraphDTO
+import cccev.f2.evidencetype.D2EvidenceTypePage
+import cccev.f2.evidencetype.model.EvidenceTypeFlat
+import cccev.f2.evidencetype.model.EvidenceTypeFlatDTO
+import cccev.f2.evidencetypelist.model.EvidenceTypeListFlat
+import f2.dsl.fnc.F2Function
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlinx.serialization.Serializable
+
+/**
+ * Get an evidence type by its id.
+ * @d2 function
+ * @parent [D2EvidenceTypePage]
+ */
+typealias EvidenceTypeListGetFunction = F2Function<EvidenceTypeListGetQuery, EvidenceTypeListGetResult>
+
+/**
+ * @d2 query
+ * @parent [EvidenceTypeListGetFunction]
+ */
+@JsExport
+@JsName("EvidenceTypeListGetQueryDTO")
+interface EvidenceTypeListGetQueryDTO {
+    /**
+     * Identifier of the data unit to get.
+     */
+    val id: EvidenceTypeId
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListGetQuery(
+    override val id: EvidenceTypeId
+): EvidenceTypeListGetQueryDTO
+
+/**
+ * @d2 result
+ * @parent [EvidenceTypeListGetFunction]
+ */
+@JsExport
+interface EvidenceTypeListGetResultDTO {
+    val item: EvidenceTypeListFlat?
+    val graph: CccevFlatGraphDTO
+}
+
+/**
+ * @d2 inherit
+ */
+@Serializable
+data class EvidenceTypeListGetResult(
+    override val item: EvidenceTypeListFlat?,
+    override val graph: CccevFlatGraph
+): EvidenceTypeListGetResultDTO

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
@@ -68,7 +68,7 @@ interface RequirementCreateCommandDTO {
      * Evidences that must be provided for the requirement to be validated. <br/>
      * @example [cccev.core.requirement.model.Requirement.hasEvidenceTypeList]
      */
-    val evidenceTypeIds: List<EvidenceTypeId>
+    val evidenceTypeListIds: List<EvidenceTypeId>
 
     /**
      * @ref [cccev.core.requirement.model.Requirement.enablingCondition]
@@ -120,7 +120,7 @@ data class RequirementCreateCommand(
     override val type: String? = null,
     override val subRequirementIds: List<RequirementId> = emptyList(),
     override val conceptIds: List<InformationConceptId> = emptyList(),
-    override val evidenceTypeIds: List<EvidenceTypeId> = emptyList(),
+    override val evidenceTypeListIds: List<EvidenceTypeId> = emptyList(),
     override val enablingCondition: String? = null,
     override val enablingConditionDependencies: List<InformationConceptId> = emptyList(),
     override val required: Boolean = true,

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
@@ -3,6 +3,7 @@ package cccev.f2.requirement.command
 import cccev.dsl.model.EvidenceTypeId
 import cccev.dsl.model.InformationConceptId
 import cccev.dsl.model.RequirementId
+import cccev.dsl.model.RequirementIdentifier
 import cccev.f2.requirement.D2RequirementPage
 import cccev.f2.requirement.model.RequirementKind
 import f2.dsl.fnc.F2Function
@@ -26,7 +27,7 @@ interface RequirementCreateCommandDTO {
      * A custom identifier for the requirement
      * @example [cccev.core.requirement.model.Requirement.identifier]
      */
-    val identifier: String?
+    val identifier: RequirementIdentifier?
 
     /**
      * Subtype used for the requirement.

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementCreateCommand.kt
@@ -56,19 +56,19 @@ interface RequirementCreateCommandDTO {
      * Sub-requirements that must be fulfilled for the requirement to be validated.
      * @example [cccev.core.requirement.model.Requirement.hasRequirement]
      */
-    val subRequirementIds: List<RequirementId>
+    val subRequirementIds: List<RequirementId>?
 
     /**
      * Concepts used by the requirement
      * @example [cccev.core.requirement.model.Requirement.hasConcept]
      */
-    val conceptIds: List<InformationConceptId>
+    val conceptIds: List<InformationConceptId>?
 
     /**
      * Evidences that must be provided for the requirement to be validated. <br/>
      * @example [cccev.core.requirement.model.Requirement.hasEvidenceTypeList]
      */
-    val evidenceTypeListIds: List<EvidenceTypeId>
+    val evidenceTypeListIds: List<EvidenceTypeId>?
 
     /**
      * @ref [cccev.core.requirement.model.Requirement.enablingCondition]
@@ -78,7 +78,7 @@ interface RequirementCreateCommandDTO {
     /**
      * @ref [cccev.core.requirement.model.Requirement.enablingConditionDependencies]
      */
-    val enablingConditionDependencies: List<InformationConceptId>
+    val enablingConditionDependencies: List<InformationConceptId>?
 
     /**
      * @ref [cccev.core.requirement.model.Requirement.required]
@@ -93,7 +93,7 @@ interface RequirementCreateCommandDTO {
     /**
      * @ref [cccev.core.requirement.model.Requirement.validatingConditionDependencies]
      */
-    val validatingConditionDependencies: List<InformationConceptId>
+    val validatingConditionDependencies: List<InformationConceptId>?
 
     val evidenceValidatingCondition: String?
 
@@ -118,14 +118,14 @@ data class RequirementCreateCommand(
     override val name: String? = null,
     override val description: String? = null,
     override val type: String? = null,
-    override val subRequirementIds: List<RequirementId> = emptyList(),
-    override val conceptIds: List<InformationConceptId> = emptyList(),
-    override val evidenceTypeListIds: List<EvidenceTypeId> = emptyList(),
+    override val subRequirementIds: List<RequirementId>? = null,
+    override val conceptIds: List<InformationConceptId>? = null,
+    override val evidenceTypeListIds: List<EvidenceTypeId>? = null,
     override val enablingCondition: String? = null,
-    override val enablingConditionDependencies: List<InformationConceptId> = emptyList(),
+    override val enablingConditionDependencies: List<InformationConceptId>? = null,
     override val required: Boolean = true,
     override val validatingCondition: String? = null,
-    override val validatingConditionDependencies: List<InformationConceptId> = emptyList(),
+    override val validatingConditionDependencies: List<InformationConceptId>? = null,
     override val evidenceValidatingCondition: String? = null,
     override val order: Int? = null,
     override val properties: Map<String, String>? = null,

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementUpdateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/requirement/command/RequirementUpdateCommand.kt
@@ -40,14 +40,14 @@ interface RequirementUpdateCommandDTO {
     val description: String?
 
     val type: String?
-    val conceptIds: List<InformationConceptId>
-    val evidenceTypeIds: List<EvidenceTypeId>
-    val subRequirementIds: List<RequirementId>
+    val conceptIds: List<InformationConceptId>?
+    val evidenceTypeIds: List<EvidenceTypeId>?
+    val subRequirementIds: List<RequirementId>?
     val enablingCondition: String?
-    val enablingConditionDependencies: List<InformationConceptId>
+    val enablingConditionDependencies: List<InformationConceptId>?
     val required: Boolean
     val validatingCondition: String?
-    val validatingConditionDependencies: List<InformationConceptId>
+    val validatingConditionDependencies: List<InformationConceptId>?
     val evidenceValidatingCondition: String?
     val order: Int?
     val properties: Map<String, String>?
@@ -62,14 +62,14 @@ data class RequirementUpdateCommand(
     override val name: String?,
     override val description: String?,
     override val type: String?,
-    override val conceptIds: List<InformationConceptId>,
-    override val evidenceTypeIds: List<EvidenceTypeId>,
-    override val subRequirementIds: List<RequirementId>,
+    override val conceptIds: List<InformationConceptId>?,
+    override val evidenceTypeIds: List<EvidenceTypeId>?,
+    override val subRequirementIds: List<RequirementId>?,
     override val enablingCondition: String?,
-    override val enablingConditionDependencies: List<InformationConceptId>,
+    override val enablingConditionDependencies: List<InformationConceptId>?,
     override val required: Boolean,
     override val validatingCondition: String?,
-    override val validatingConditionDependencies: List<InformationConceptId>,
+    override val validatingConditionDependencies: List<InformationConceptId>?,
     override val evidenceValidatingCondition: String?,
     override val order: Int?,
     override val properties: Map<String, String>?

--- a/cccev-test/src/main/kotlin/cccev/test/f2/requirement/command/RequirementCreateSteps.kt
+++ b/cccev-test/src/main/kotlin/cccev/test/f2/requirement/command/RequirementCreateSteps.kt
@@ -72,7 +72,7 @@ class RequirementCreateSteps: En, CccevCucumberStepsDefinition() {
                     type = command.type,
                     hasRequirement = command.subRequirementIds,
                     hasConcept = command.conceptIds,
-                    hasEvidenceType = command.evidenceTypeIds,
+                    hasEvidenceType = command.evidenceTypeListIds,
                 )
             }
         }
@@ -107,7 +107,7 @@ class RequirementCreateSteps: En, CccevCucumberStepsDefinition() {
             type = params.type,
             subRequirementIds = params.hasRequirement.map { context.requirementIds[it] ?: it },
             conceptIds = params.hasConcept.map { context.conceptIds[it] ?: it },
-            evidenceTypeIds = params.hasEvidenceType.map { context.evidenceTypeIds[it] ?: it },
+            evidenceTypeListIds = params.hasEvidenceType.map { context.evidenceTypeIds[it] ?: it },
             validatingCondition = params.validatingCondition,
             validatingConditionDependencies = params.validatingConditionDependencies.map { context.conceptIds[it] ?: it },
             evidenceValidatingCondition = params.evidenceValidatingCondition,

--- a/cccev-test/src/main/kotlin/cccev/test/f2/requirement/data/AssertionRequirement.kt
+++ b/cccev-test/src/main/kotlin/cccev/test/f2/requirement/data/AssertionRequirement.kt
@@ -28,9 +28,9 @@ class AssertionRequirement(
             name: String? = requirement.name,
             description: String? = requirement.description,
             type: String? = requirement.type,
-            hasRequirement: List<RequirementId> = requirement.subRequirements.map { it.id },
-            hasConcept: List<InformationConceptId> = requirement.concepts.map { it.id },
-            hasEvidenceType: List<EvidenceTypeId> = requirement.evidenceTypes.map { it.id },
+            hasRequirement: List<RequirementId>? = requirement.subRequirements.map { it.id },
+            hasConcept: List<InformationConceptId>? = requirement.concepts.map { it.id },
+            hasEvidenceType: List<EvidenceTypeId>? = requirement.evidenceTypes.map { it.id },
         ) = also {
             Assertions.assertThat(requirement.id).isEqualTo(id)
             Assertions.assertThat(requirement.kind).isEqualTo(kind)


### PR DESCRIPTION
- Refactor `GraphUnflatUtils.kt` to remove unused imports and fix parameter syntax for better code maintainability.
- Add support for `EvidenceTypeList` in the unflattening process, improving requirement model flexibility.
- Refine entity naming conventions and update `Requirement` and command identifiers to align with new evidence model.





