### PR TITLE
Remove redundant id property from EvidenceDTO and Evidence classes

### DIFF
--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Evidence.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Evidence.kt
@@ -37,10 +37,6 @@ typealias EvidenceIdentifier = String
 @JsName("EvidenceDTO")
 interface EvidenceDTO {
     /**
-     * The unique id of the evidence.
-     */
-    val id: EvidenceId
-    /**
      * The unique identifier of the evidence.
      */
     val identifier: EvidenceIdentifier
@@ -79,7 +75,6 @@ interface EvidenceDTO {
  */
 @Serializable
 open class Evidence(
-    override val id: EvidenceId,
     override val identifier: EvidenceIdentifier,
     override val isConformantTo: List<EvidenceTypeId> = emptyList(),
     override val supportsValue: List<SupportedValueId> = emptyList(),


### PR DESCRIPTION
The id property has been removed from the EvidenceDTO interface and Evidence class as it was redundant. The identifier property serves as the unique identifier, simplifying the data model and reducing maintenance complexity.