### PR TITLE
Refactor models: make description and related fields nullable for enhanced flexibility

### DIFF
--- a/cccev-core/src/jvmMain/kotlin/cccev/core/unit/entity/DataUnitEntity.kt
+++ b/cccev-core/src/jvmMain/kotlin/cccev/core/unit/entity/DataUnitEntity.kt
@@ -22,7 +22,7 @@ class DataUnitEntity {
 
     lateinit var name: String
 
-    lateinit var description: String
+    var description: String? = null
 
     var notation: String? = null
 

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -15,6 +15,7 @@ import cccev.dsl.model.InformationRequirement
 import cccev.dsl.model.Requirement
 import cccev.dsl.model.RequirementCertification
 import cccev.dsl.model.SupportedValue
+import cccev.dsl.model.nullIfEmpty
 import cccev.f2.CccevFlatGraph
 import cccev.f2.certification.model.CertificationFlat
 import cccev.f2.certification.model.RequirementCertificationFlat
@@ -276,10 +277,10 @@ fun DataUnitFlat.unflatten(graph: CccevFlatGraph): DataUnit {
         description = description,
         notation = notation,
         type = DataUnitType.valueOf(type),
-        options = optionIdentifiers.map {
+        options = optionIdentifiers?.map {
             graph.unitOptions[it]?.unflatten()
                 ?: throw NotFoundException("DataUnitOption", it)
-        }
+        }.nullIfEmpty()
     )
 }
 

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
@@ -59,14 +59,14 @@ open class Criterion(
     override val hasEvidenceTypeList: List<EvidenceTypeListBase>? = null,
     override val isDerivedFrom: List<ReferenceFramework>? = null,
     override var isRequirementOf: List<Requirement>? = null,
-    override val enablingCondition: String?,
+    override val enablingCondition: String? = null,
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
-    override val validatingCondition: String?,
+    override val validatingCondition: String? = null,
     override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
-    override val order: Int?,
-    override val properties: Map<String, String>?,
-    override val evidenceValidatingCondition: String?,
+    override val order: Int? = null,
+    override val properties: Map<String, String>? = null,
+    override val evidenceValidatingCondition: String? = null,
 ) : Requirement {
     override val kind: String = "CRITERION"
     override fun toString(): String {
@@ -100,14 +100,14 @@ open class InformationRequirement(
     override val hasEvidenceTypeList: List<EvidenceTypeList>? = null,
     override val isDerivedFrom: List<ReferenceFramework>? = null,
     override var isRequirementOf: List<Requirement>? = null,
-    override val enablingCondition: String?,
+    override val enablingCondition: String? = null,
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
-    override val validatingCondition: String?,
+    override val validatingCondition: String? = null,
     override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
-    override val order: Int?,
-    override val properties: Map<String, String>?,
-    override val evidenceValidatingCondition: String?,
+    override val order: Int? = null,
+    override val properties: Map<String, String>? = null,
+    override val evidenceValidatingCondition: String? = null,
 ) : Requirement {
     override val kind: String = "INFORMATION"
     override fun toString(): String {
@@ -174,7 +174,7 @@ open class RequirementRef(
     override val hasRequirement: List<Requirement>? = null
     override var isRequirementOf: List<Requirement>? = null
     override val hasConcept: List<InformationConcept>? = null
-    override val hasEvidenceTypeList: List<EvidenceTypeListBase>? = null
+    override val hasEvidenceTypeList: List<EvidenceTypeList>? = null
     override val enablingCondition: String? = null
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null
     override val required: Boolean = true
@@ -195,22 +195,22 @@ open class PartialRequirement(
     override val id: RequirementId,
     override val identifier: RequirementIdentifier,
     override val description: String?,
-    override val name: String?,
-    override val type: String?,
+    override val name: String? = null,
+    override val type: String? = null,
     val minRequirementsToMeet: Int,
     override val hasConcept: List<InformationConceptBase>? = null,
     override val hasRequirement: List<Requirement>? = null,
     override val hasEvidenceTypeList: List<EvidenceTypeListBase>? = null,
     override val isDerivedFrom: List<ReferenceFramework>? = null,
     override var isRequirementOf: List<Requirement>? = null,
-    override val enablingCondition: String?,
+    override val enablingCondition: String? = null,
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
-    override val validatingCondition: String?,
+    override val validatingCondition: String? = null,
     override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
-    override val order: Int?,
-    override val properties: Map<String, String>?,
-    override val evidenceValidatingCondition: String?,
+    override val order: Int? = null,
+    override val properties: Map<String, String>? = null,
+    override val evidenceValidatingCondition: String? = null,
 ): Requirement {
     override val kind: String = "PARTIAL"
 }

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Units.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Units.kt
@@ -21,7 +21,7 @@ typealias DataUnitIdentifier = String
 interface DataUnitDTO {
     val identifier: DataUnitIdentifier
     val name: String
-    val description: String
+    val description: String?
     val notation: String?
     val type: DataUnitType
     val options: List<DataUnitOption>?
@@ -31,7 +31,7 @@ interface DataUnitDTO {
 open class DataUnit(
     override val identifier: DataUnitIdentifier,
     override val name: String,
-    override val description: String,
+    override val description: String? = null,
     override val notation: String? = null,
     override val type: DataUnitType,
     override val options: List<DataUnitOption>? = null

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Utils.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Utils.kt
@@ -1,0 +1,5 @@
+package cccev.dsl.model
+
+
+fun <T> List<T>?.nullIfEmpty(): List<T>? = this?.takeIf { it.isNotEmpty() }
+fun <T, R> Map<T, R>?.nullIfEmpty(): Map<T, R>? = this?.takeIf { it.isNotEmpty() }

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/builder/RequirementsLinkedBuilder.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/builder/RequirementsLinkedBuilder.kt
@@ -5,6 +5,7 @@ import cccev.dsl.model.Constraint
 import cccev.dsl.model.Criterion
 import cccev.dsl.model.InformationRequirement
 import cccev.dsl.model.Requirement
+import cccev.dsl.model.nullIfEmpty
 import com.benasher44.uuid.uuid4
 
 class RequirementsLinkedBuilder {
@@ -120,6 +121,3 @@ class ConstraintBuilder: RequirementBuilder<Constraint>, AbstractRequirementBuil
         evidenceValidatingCondition = evidenceValidatingCondition
     )
 }
-
-fun <T> List<T>?.nullIfEmpty(): List<T>? = this?.takeIf { it.isNotEmpty() }
-fun <T, R> Map<T, R>?.nullIfEmpty(): Map<T, R>? = this?.takeIf { it.isNotEmpty() }

--- a/cccev-f2/cccev-f2-api/src/main/kotlin/cccev/f2/unit/model/DataUnitExtension.kt
+++ b/cccev-f2/cccev-f2-api/src/main/kotlin/cccev/f2/unit/model/DataUnitExtension.kt
@@ -4,6 +4,7 @@ import cccev.core.unit.entity.DataUnitEntity
 import cccev.core.unit.entity.DataUnitOptionEntity
 import cccev.dsl.model.DataUnitIdentifier
 import cccev.dsl.model.DataUnitOptionIdentifier
+import cccev.dsl.model.nullIfEmpty
 import cccev.f2.CccevFlatGraph
 
 fun DataUnitEntity.flattenTo(graph: CccevFlatGraph): DataUnitIdentifier {
@@ -14,14 +15,13 @@ fun DataUnitEntity.flattenTo(graph: CccevFlatGraph): DataUnitIdentifier {
         description = description,
         notation = notation,
         type = type.name,
-        optionIdentifiers = options.map { it.flattenTo(graph) }
+        optionIdentifiers = options.map { it.flattenTo(graph) }.nullIfEmpty()
     )
     return identifier
 }
 
 fun DataUnitOptionEntity.flattenTo(graph: CccevFlatGraph): DataUnitOptionIdentifier {
     graph.unitOptions[identifier] = cccev.dsl.model.DataUnitOption(
-//        id = id,
         identifier = identifier,
         name = name,
         value = value,

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/concept/command/InformationConceptUpdateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/concept/command/InformationConceptUpdateCommand.kt
@@ -61,8 +61,8 @@ data class InformationConceptUpdateCommand(
     override val id: InformationConceptId,
     override val name: String,
     override val description: String?,
-    override val expressionOfExpectedValue: String?,
-    override val dependsOn: List<InformationConceptId>?
+    override val expressionOfExpectedValue: String? = null,
+    override val dependsOn: List<InformationConceptId>? = null
 ): InformationConceptUpdateCommandDTO
 
 /**

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/model/EvidenceTypeListFlat.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/evidencetypelist/model/EvidenceTypeListFlat.kt
@@ -51,5 +51,5 @@ data class EvidenceTypeListFlat(
     override val identifier: EvidenceTypeIdentifier,
     override val name: String,
     override val description: String,
-    override val specifiesEvidenceType: List<EvidenceTypeListIdentifier>?,
+    override val specifiesEvidenceType: List<EvidenceTypeListIdentifier>? = null,
 ): EvidenceTypeListFlatDTO

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/command/DataUnitCreateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/command/DataUnitCreateCommand.kt
@@ -35,7 +35,7 @@ data class DataUnitCreateCommand(
      * The description of the data unit.
      * @example [cccev.s2.unit.domain.model.DataUnit.description]
      */
-    val description: String,
+    val description: String? = null,
 
     /**
      * The notation of the data unit.

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/command/DataUnitUpdateCommand.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/command/DataUnitUpdateCommand.kt
@@ -34,7 +34,7 @@ data class DataUnitUpdateCommand(
      * The description of the data unit.
      * @example [cccev.s2.unit.domain.model.DataUnit.description]
      */
-    val description: String,
+    val description: String? = null,
 
     /**
      * The notation of the data unit.
@@ -45,7 +45,7 @@ data class DataUnitUpdateCommand(
     /**
      * @ref [cccev.s2.unit.domain.model.DataUnit.options]
      */
-    val options: List<DataUnitOptionCommand>?
+    val options: List<DataUnitOptionCommand>? = null,
 )
 
 /**

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/model/DataUnitFlat.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/unit/model/DataUnitFlat.kt
@@ -32,7 +32,7 @@ interface DataUnitFlatDTO {
     /**
      * @ref [DataUnitDTO.description]
      */
-    val description: String
+    val description: String?
 
     /**
      * @ref [DataUnitDTO.notation]
@@ -47,7 +47,7 @@ interface DataUnitFlatDTO {
     /**
      * @ref [DataUnitDTO.options]
      */
-    val optionIdentifiers: List<DataUnitOptionIdentifier>
+    val optionIdentifiers: List<DataUnitOptionIdentifier>?
 }
 
 /**
@@ -58,8 +58,8 @@ data class DataUnitFlat(
     override val id: DataUnitId,
     override val identifier: DataUnitIdentifier,
     override val name: String,
-    override val description: String,
+    override val description: String? = null,
     override val notation: String? = null,
     override val type: String,
-    override val optionIdentifiers: List<DataUnitOptionIdentifier>
+    override val optionIdentifiers: List<DataUnitOptionIdentifier>? = null
 ): DataUnitFlatDTO

--- a/cccev-test/src/main/kotlin/cccev/test/f2/unit/data/AssertionDataUnit.kt
+++ b/cccev-test/src/main/kotlin/cccev/test/f2/unit/data/AssertionDataUnit.kt
@@ -23,7 +23,7 @@ class AssertionDataUnit(
         fun hasFields(
             id: DataUnitId = unit.id,
             name: String = unit.name,
-            description: String = unit.description,
+            description: String? = unit.description,
             notation: String? = unit.notation,
             type: DataUnitType = unit.type
         ) = also {


### PR DESCRIPTION
- Made `description` and related fields nullable across various models, allowing optional fields where applicable.
- Added `nullIfEmpty` utility functions to represent empty collections as null, improving robustness and adaptability in data handling.
