### PR TITLE
Fix nullable dependencies in InformationConcept and simplify Docker Compose configuration

### DIFF
--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -101,11 +101,11 @@ fun InformationConceptFlat.unflatten(graph: CccevFlatGraph): InformationConcept 
         ?.unflatten(graph)
         ?: throw NotFoundException("DataUnit", unitIdentifier)
 
-    val dependencies = dependsOn.map { dependencyIdentifier ->
+    val dependencies = dependsOn?.map { dependencyIdentifier ->
         graph.concepts[dependencyIdentifier]
             ?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", dependencyIdentifier)
-    }.map { it.id }
+    }?.map { it.id }.nullIfEmpty()
     return InformationConceptBase(
         id = id,
         identifier = identifier,

--- a/cccev-f2/cccev-f2-api/src/main/kotlin/cccev/f2/concept/model/InformationConceptExtension.kt
+++ b/cccev-f2/cccev-f2-api/src/main/kotlin/cccev/f2/concept/model/InformationConceptExtension.kt
@@ -2,6 +2,7 @@ package cccev.f2.concept.model
 
 import cccev.core.concept.entity.InformationConceptEntity
 import cccev.dsl.model.InformationConceptIdentifier
+import cccev.dsl.model.nullIfEmpty
 import cccev.f2.CccevFlatGraph
 import cccev.f2.unit.model.flattenTo
 
@@ -13,7 +14,7 @@ fun InformationConceptEntity.flattenTo(graph: CccevFlatGraph): InformationConcep
         unitIdentifier = unit.flattenTo(graph),
         description = description,
         expressionOfExpectedValue = expressionOfExpectedValue,
-        dependsOn = dependencies.map { it.flattenTo(graph) }
+        dependsOn = dependencies.map { it.flattenTo(graph) }.nullIfEmpty()
     )
     return identifier
 }

--- a/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/concept/model/InformationConceptFlat.kt
+++ b/cccev-f2/cccev-f2-domain/src/commonMain/kotlin/cccev/f2/concept/model/InformationConceptFlat.kt
@@ -46,7 +46,7 @@ interface InformationConceptFlatDTO {
     /**
      * @ref [InformationConceptDTO.dependsOn]
      */
-    val dependsOn: List<InformationConceptIdentifier>
+    val dependsOn: List<InformationConceptIdentifier>?
 }
 
 /**
@@ -60,5 +60,5 @@ data class InformationConceptFlat(
     override val unitIdentifier: DataUnitIdentifier,
     override val description: String?,
     override val expressionOfExpectedValue: String?,
-    override val dependsOn: List<InformationConceptIdentifier>
+    override val dependsOn: List<InformationConceptIdentifier>?
 ): InformationConceptFlatDTO

--- a/cccev-test/src/main/kotlin/cccev/test/f2/concept/command/InformationConceptCreateSteps.kt
+++ b/cccev-test/src/main/kotlin/cccev/test/f2/concept/command/InformationConceptCreateSteps.kt
@@ -123,7 +123,7 @@ class InformationConceptCreateSteps: En, CccevCucumberStepsDefinition() {
             hasUnit = context.unitIds[params.unit] ?: params.unit,
             description = params.description,
             expressionOfExpectedValue = params.expressionOfExpectedValue,
-            dependsOn = params.dependsOn.map(context.conceptIds::safeGet)
+            dependsOn = params.dependsOn?.map(context.conceptIds::safeGet)
         )
         command.invokeWith(informationConceptEndpoint.conceptCreate()).id
     }
@@ -134,7 +134,7 @@ class InformationConceptCreateSteps: En, CccevCucumberStepsDefinition() {
         unit = entry?.get("unit") ?: context.unitIds.lastUsedKey,
         description = entry?.get("description").orRandom(),
         expressionOfExpectedValue = entry?.get("expressionOfExpectedValue"),
-        dependsOn = entry?.extractList("dependsOn") ?: emptyList()
+        dependsOn = entry?.extractList("dependsOn")
     )
 
     private data class InformationConceptCreateParams(
@@ -143,7 +143,7 @@ class InformationConceptCreateSteps: En, CccevCucumberStepsDefinition() {
         val unit: TestContextKey,
         val description: String,
         val expressionOfExpectedValue: String?,
-        val dependsOn: List<TestContextKey>
+        val dependsOn: List<TestContextKey>?
     )
 
     private fun informationConceptAssertParams(entry: Map<String, String>) = InformationConceptAssertParams(

--- a/infra/docker-compose/docker-compose-c2-sandbox-ssm.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox-ssm.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
 
   cli-init-ssm.bc-coop.bclan:

--- a/infra/docker-compose/docker-compose-c2-sandbox.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   ca.bc-coop.bclan:
     container_name: ca-bclan-${DOCKER_NETWORK}

--- a/infra/docker-compose/docker-compose-fs.yml
+++ b/infra/docker-compose/docker-compose-fs.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   cccev-fs:
     container_name: cccev-fs

--- a/infra/docker-compose/docker-compose-neo4j.yml
+++ b/infra/docker-compose/docker-compose-neo4j.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   neo4j:
     image: neo4j:5.5.0


### PR DESCRIPTION
- Removed the version specification in docker-compose files to let Docker Compose select the best version automatically.
- This change simplifies configuration and maintains compatibility with the latest Docker Compose features.
