### PR TITLE
Refactor: Use InformationConcept for validatingConditionDependencies for improved type safety

### DIFF
--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVGraphClient.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/CCCEVGraphClient.kt
@@ -171,12 +171,12 @@ class CCCEVGraphClient(
                 ,
             subRequirementIds = requirement.hasRequirement?.map { context.processedRequirements[it.identifier]!! },
             kind = RequirementKind.valueOf(requirement.kind),
-            type = requirement.type?.toString(),
+            type = requirement.type,
             enablingCondition = requirement.enablingCondition,
             enablingConditionDependencies = requirement.enablingConditionDependencies?.map { context.processedConcepts[it]!! },
             required = requirement.required,
             validatingCondition = requirement.validatingCondition,
-            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it]!! },
+            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it.identifier]!! },
             order = requirement.order,
             properties = requirement.properties
         ).invokeWith(requirementClient.requirementCreate()).id
@@ -200,7 +200,7 @@ class CCCEVGraphClient(
             enablingConditionDependencies = requirement.enablingConditionDependencies?.map { context.processedConcepts[it]!! },
             required = requirement.required,
             validatingCondition = requirement.validatingCondition,
-            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it]!! },
+            validatingConditionDependencies = requirement.validatingConditionDependencies?.map { context.processedConcepts[it.identifier]!! },
             order = requirement.order,
             properties = requirement.properties,
             evidenceValidatingCondition = requirement.evidenceValidatingCondition,

--- a/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
+++ b/cccev-dsl/cccev-dsl-client/src/jvmMain/kotlin/cccev/dsl/client/model/GraphUnflatUtils.kt
@@ -161,7 +161,7 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
     val validatingConditionDependencies = validatingConditionDependencies.map {
         graph.concepts[it]?.unflatten(graph)
             ?: throw NotFoundException("InformationConcept", it)
-    }.map { it.id }.ifEmpty { null }
+    }
     return when(RequirementKind.valueOf(kind)) {
         RequirementKind.CONSTRAINT -> asConstant(
             enablingConditionDependencies,
@@ -189,7 +189,7 @@ fun RequirementFlat.unflatten(graph: CccevFlatGraph): Requirement {
 
 private fun RequirementFlat.asInformationRequirement(
     enablingConditionDependencies: List<InformationConceptId>?,
-    validatingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConcept>?,
     subRequirements: List<Requirement>?,
     concepts: List<InformationConcept>?,
     evidenceTypeLists: List<EvidenceTypeListBase>?
@@ -218,7 +218,7 @@ private fun RequirementFlat.asInformationRequirement(
 
 private fun RequirementFlat.asCriterion(
     enablingConditionDependencies: List<InformationConceptId>?,
-    validatingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConcept>?,
     subRequirements: List<Requirement>?,
     concepts: List<InformationConcept>?,
     evidenceTypeLists: List<EvidenceTypeListBase>?
@@ -245,7 +245,7 @@ private fun RequirementFlat.asCriterion(
 
 private fun RequirementFlat.asConstant(
     enablingConditionDependencies: List<InformationConceptId>?,
-    validatingConditionDependencies: List<InformationConceptId>?,
+    validatingConditionDependencies: List<InformationConcept>?,
     subRequirements: List<Requirement>?,
     concepts: List<InformationConcept>?,
     evidenceTypeLists: List<EvidenceTypeListBase>?

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/Requirement.kt
@@ -38,7 +38,7 @@ sealed interface Requirement {
     val required: Boolean
     val validatingCondition: String?
     val evidenceValidatingCondition: String?
-    val validatingConditionDependencies: List<InformationConceptIdentifier>?
+    val validatingConditionDependencies: List<InformationConcept>?
     val order: Int?
     val properties: Map<String, String>?
 }
@@ -63,7 +63,7 @@ open class Criterion(
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
     override val validatingCondition: String? = null,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
+    override val validatingConditionDependencies: List<InformationConcept>? = null,
     override val order: Int? = null,
     override val properties: Map<String, String>? = null,
     override val evidenceValidatingCondition: String? = null,
@@ -104,7 +104,7 @@ open class InformationRequirement(
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
     override val validatingCondition: String? = null,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
+    override val validatingConditionDependencies: List<InformationConcept>? = null,
     override val order: Int? = null,
     override val properties: Map<String, String>? = null,
     override val evidenceValidatingCondition: String? = null,
@@ -141,7 +141,7 @@ open class Constraint(
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
     override val validatingCondition: String?,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
+    override val validatingConditionDependencies: List<InformationConcept>? = null,
     override val order: Int?,
     override val properties: Map<String, String>?,
     override val evidenceValidatingCondition: String?,
@@ -179,7 +179,7 @@ open class RequirementRef(
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null
     override val required: Boolean = true
     override val validatingCondition: String? = null
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null
+    override val validatingConditionDependencies: List<InformationConcept>? = null
     override val order: Int? = null
     override val properties: Map<String, String>? = null
     override val kind: String = "REFERENCE"
@@ -207,7 +207,7 @@ open class PartialRequirement(
     override val enablingConditionDependencies: List<InformationConceptIdentifier>? = null,
     override val required: Boolean,
     override val validatingCondition: String? = null,
-    override val validatingConditionDependencies: List<InformationConceptIdentifier>? = null,
+    override val validatingConditionDependencies: List<InformationConcept>? = null,
     override val order: Int? = null,
     override val properties: Map<String, String>? = null,
     override val evidenceValidatingCondition: String? = null,

--- a/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/builder/RequirementBuilder.kt
+++ b/cccev-dsl/cccev-dsl-model/src/commonMain/kotlin/cccev/dsl/model/builder/RequirementBuilder.kt
@@ -22,7 +22,7 @@ interface RequirementBuilder<T : Requirement> {
     var enablingConditionDependencies: List<InformationConceptIdentifier>
     var required: Boolean
     var validatingCondition: String?
-    var validatingConditionDependencies: List<InformationConceptIdentifier>
+    var validatingConditionDependencies: List<InformationConcept>
     var order: Int?
     var properties: Map<String, String>?
 
@@ -60,7 +60,7 @@ abstract class AbstractRequirementBuilder<T : Requirement> : RequirementBuilder<
     override var enablingConditionDependencies: List<InformationConceptIdentifier> = mutableListOf()
     override var required: Boolean = true
     override var validatingCondition: String? = null
-    override var validatingConditionDependencies: List<InformationConceptIdentifier> = mutableListOf()
+    override var validatingConditionDependencies: List<InformationConcept> = mutableListOf()
     override var order: Int? = null
     override var properties: Map<String, String>? = null
 


### PR DESCRIPTION
- Changed `validatingConditionDependencies` to use `InformationConcept` instead of `InformationConceptIdentifier` to enhance type safety and consistency.
- Simplified code by removing unnecessary identifier conversions and null checks, ensuring direct access to concept objects.
