### PR TITLE
Fix certification persistence and refactor dependency identifiers for data consistency

### DIFF
--- a/cccev-core/src/jvmMain/kotlin/cccev/core/certification/CertificationAggregateService.kt
+++ b/cccev-core/src/jvmMain/kotlin/cccev/core/certification/CertificationAggregateService.kt
@@ -30,7 +30,7 @@ import org.neo4j.ogm.session.SessionFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
-@Service("CertificationAggregateService2")
+@Service("CertificationAggregateService")
 class CertificationAggregateService(
     private val applicationEventPublisher: ApplicationEventPublisher,
     private val certificationEvidenceService: CertificationEvidenceService,
@@ -137,7 +137,7 @@ class CertificationAggregateService(
     private suspend fun RequirementEntity.toEmptyCertification(
         existingCertifications: MutableMap<RequirementIdentifier, RequirementCertificationEntity> = mutableMapOf()
     ): RequirementCertificationEntity {
-        return existingCertifications[identifier]
+        val requirementCertification = existingCertifications[identifier]
             ?: RequirementCertificationEntity().also { certification ->
                 existingCertifications[identifier] = certification
 
@@ -152,5 +152,7 @@ class CertificationAggregateService(
                 certification.areEvidencesProvided = evidenceValidatingCondition == null
                 certification.isFulfilled = certification.isFulfilled()
             }
+        certificationRepository.save(requirementCertification)
+        return certificationRepository.findRequirementCertificationById(requirementCertification.id)!!
     }
 }


### PR DESCRIPTION
- Renamed service to "CertificationAggregateService" for clarity and ensured certification entity persistence to address consistency in the certification process.
- Replaced `InformationConcept` with `InformationConceptIdentifier` and added identifier field to `SupportedValueEntity` and `SupportedValueFlat` for improved traceability and simplified dependency handling.
