### PR TITLE
chore(build.gradle.kts): update dependencies version from 0.22.0-SNAPSHOT to 0.23.0-SNAPSHOT

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 }
 
 dependencies {
-	implementation("io.komune.fixers.gradle:dependencies:0.22.0-SNAPSHOT")
+	implementation("io.komune.fixers.gradle:dependencies:0.23.0-SNAPSHOT")
 }


### PR DESCRIPTION
Updating the dependencies version ensures that the project uses the latest features and bug fixes provided in the new version, which can improve stability and performance.